### PR TITLE
Allow null values instead of forcing a string

### DIFF
--- a/src/Http/Livewire/QuillTextEditor.php
+++ b/src/Http/Livewire/QuillTextEditor.php
@@ -13,7 +13,7 @@ use Livewire\Component;
 class QuillTextEditor extends Component
 {
     #[Modelable]
-    public string $value = '';
+    public string | null $value = '';
 
     #[Locked]
     public string $quillId;


### PR DESCRIPTION
This would allow for empty values that are not set yet in the parent component. For example;

We have a component that has a $formData array property. Using wire:model.live="formData.something" will throw an error because the value is still null and not yet a string.